### PR TITLE
Convert specs to RSpec 3.8.0 syntax with Transpec

### DIFF
--- a/spec/controllers/admin/budgets_controller_spec.rb
+++ b/spec/controllers/admin/budgets_controller_spec.rb
@@ -37,7 +37,7 @@ describe Admin::BudgetsController do
     it "assigns all budgets as @budgets" do
       budget = Budget.create! valid_attributes
       get :index, {}, valid_session
-      assigns(:budgets).should eq([budget])
+      expect(assigns(:budgets)).to eq([budget])
     end
   end
 
@@ -45,14 +45,14 @@ describe Admin::BudgetsController do
     it "assigns the requested budget as @budget" do
       budget = Budget.create! valid_attributes
       get :show, {:id => budget.to_param}, valid_session
-      assigns(:budget).should eq(budget)
+      expect(assigns(:budget)).to eq(budget)
     end
   end
 
   describe "GET new" do
     it "assigns a new budget as @budget" do
       get :new, {}, valid_session
-      assigns(:budget).should be_a_new(Budget)
+      expect(assigns(:budget)).to be_a_new(Budget)
     end
   end
 
@@ -60,7 +60,7 @@ describe Admin::BudgetsController do
     it "assigns the requested budget as @budget" do
       budget = Budget.create! valid_attributes
       get :edit, {:id => budget.to_param}, valid_session
-      assigns(:budget).should eq(budget)
+      expect(assigns(:budget)).to eq(budget)
     end
   end
 
@@ -74,32 +74,32 @@ describe Admin::BudgetsController do
 
       it "assigns a newly created budget as @budget" do
         post :create, {:budget => valid_attributes}, valid_session
-        assigns(:budget).should be_a(Budget)
-        assigns(:budget).should be_persisted
+        expect(assigns(:budget)).to be_a(Budget)
+        expect(assigns(:budget)).to be_persisted
       end
 
       it "redirects to the created budget" do
         post :create, {:budget => valid_attributes}, valid_session
-        response.should redirect_to(admin_budgets_url)
+        expect(response).to redirect_to(admin_budgets_url)
       end
     end
 
     describe "with invalid params" do
       before do
-        Budget.any_instance.stub(:save).and_return(false)
-        Budget.any_instance.stub(:errors).and_return({ amount: "invalid" })
+        allow_any_instance_of(Budget).to receive(:save).and_return(false)
+        allow_any_instance_of(Budget).to receive(:errors).and_return({ amount: "invalid" })
       end
 
       it "assigns a newly created but unsaved budget as @budget" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:budget => { "title" => "invalid value" }}, valid_session
-        assigns(:budget).should be_a_new(Budget)
+        expect(assigns(:budget)).to be_a_new(Budget)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:budget => { "title" => "invalid value" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -112,40 +112,40 @@ describe Admin::BudgetsController do
         # specifies that the Budget created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        Budget.any_instance.should_receive(:update).with({ "title" => "MyString" })
+        expect_any_instance_of(Budget).to receive(:update).with({ "title" => "MyString" })
         put :update, {:id => budget.to_param, :budget => { "title" => "MyString" }}, valid_session
       end
 
       it "assigns the requested budget as @budget" do
         budget = Budget.create! valid_attributes
         put :update, {:id => budget.to_param, :budget => valid_attributes}, valid_session
-        assigns(:budget).should eq(budget)
+        expect(assigns(:budget)).to eq(budget)
       end
 
       it "redirects to the budget" do
         budget = Budget.create! valid_attributes
         put :update, {:id => budget.to_param, :budget => valid_attributes}, valid_session
-        response.should redirect_to(admin_budgets_url)
+        expect(response).to redirect_to(admin_budgets_url)
       end
     end
 
     describe "with invalid params" do
       let(:budget) { Budget.create! valid_attributes }
       before do
-        Budget.any_instance.stub(:save).and_return(false)
-        Budget.any_instance.stub(:errors).and_return({ amount: "invalid" })
+        allow_any_instance_of(Budget).to receive(:save).and_return(false)
+        allow_any_instance_of(Budget).to receive(:errors).and_return({ amount: "invalid" })
       end
 
       it "assigns the budget as @budget" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => budget.to_param, :budget => { title: "" }}, valid_session
-        assigns(:budget).should eq(budget)
+        expect(assigns(:budget)).to eq(budget)
       end
 
       it "re-renders the 'edit' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => budget.to_param, :budget => { title: "" }}, valid_session
-        response.status.should eq 302
+        expect(response.status).to eq 302
       end
     end
   end
@@ -161,7 +161,7 @@ describe Admin::BudgetsController do
     it "redirects to the budgets list" do
       budget = Budget.create! valid_attributes
       delete :destroy, {:id => budget.to_param}, valid_session
-      response.should redirect_to(admin_budgets_url)
+      expect(response).to redirect_to(admin_budgets_url)
     end
   end
 

--- a/spec/controllers/admin/groups_controller_spec.rb
+++ b/spec/controllers/admin/groups_controller_spec.rb
@@ -16,14 +16,14 @@ describe Admin::GroupsController do
     it "assigns all groups as @groups" do
       group = Group.create! valid_attributes
       get :index, {}, valid_session
-      assigns(:groups).should eq([group])
+      expect(assigns(:groups)).to eq([group])
     end
   end
 
   describe "GET new" do
     it "assigns a new group as @group" do
       get :new, {}, valid_session
-      assigns(:group).should be_a_new(Group)
+      expect(assigns(:group)).to be_a_new(Group)
     end
   end
 
@@ -31,7 +31,7 @@ describe Admin::GroupsController do
     it "assigns the requested group as @group" do
       group = Group.create! valid_attributes
       get :edit, {:id => group.to_param}, valid_session
-      assigns(:group).should eq(group)
+      expect(assigns(:group)).to eq(group)
     end
   end
 
@@ -45,32 +45,32 @@ describe Admin::GroupsController do
 
       it "assigns a newly created group as @group" do
         post :create, {:group => valid_attributes}, valid_session
-        assigns(:group).should be_a(Group)
-        assigns(:group).should be_persisted
+        expect(assigns(:group)).to be_a(Group)
+        expect(assigns(:group)).to be_persisted
       end
 
       it "redirects to the created group" do
         post :create, {:group => valid_attributes}, valid_session
-        response.should redirect_to(admin_groups_url)
+        expect(response).to redirect_to(admin_groups_url)
       end
     end
 
     describe "with invalid params" do
       before do
-        Group.any_instance.stub(:save).and_return(false)
-        Group.any_instance.stub(:errors).and_return({ name: "invalid" })
+        allow_any_instance_of(Group).to receive(:save).and_return(false)
+        allow_any_instance_of(Group).to receive(:errors).and_return({ name: "invalid" })
       end
 
       it "assigns a newly created but unsaved group as @group" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:group => { "name" => "invalid value" }}, valid_session
-        assigns(:group).should be_a_new(Group)
+        expect(assigns(:group)).to be_a_new(Group)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:group => { "name" => "invalid value" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -83,40 +83,40 @@ describe Admin::GroupsController do
         # specifies that the Group created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        Group.any_instance.should_receive(:update).with({ "name" => "MyString" })
+        expect_any_instance_of(Group).to receive(:update).with({ "name" => "MyString" })
         put :update, {:id => group.to_param, :group => { "name" => "MyString" }}, valid_session
       end
 
       it "assigns the requested group as @group" do
         group = Group.create! valid_attributes
         put :update, {:id => group.to_param, :group => valid_attributes}, valid_session
-        assigns(:group).should eq(group)
+        expect(assigns(:group)).to eq(group)
       end
 
       it "redirects to the group" do
         group = Group.create! valid_attributes
         put :update, {:id => group.to_param, :group => valid_attributes}, valid_session
-        response.should redirect_to(admin_groups_url)
+        expect(response).to redirect_to(admin_groups_url)
       end
     end
 
     describe "with invalid params" do
       let(:group) { Group.create! valid_attributes }
       before do
-        Group.any_instance.stub(:save).and_return(false)
-        Group.any_instance.stub(:errors).and_return({ name: "invalid" })
+        allow_any_instance_of(Group).to receive(:save).and_return(false)
+        allow_any_instance_of(Group).to receive(:errors).and_return({ name: "invalid" })
       end
 
       it "assigns the group as @group" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => group.to_param, :group => { name: "" }}, valid_session
-        assigns(:group).should eq(group)
+        expect(assigns(:group)).to eq(group)
       end
 
       it "re-renders the 'edit' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => group.to_param, :group => { name: "" }}, valid_session
-        response.status.should eq 302
+        expect(response.status).to eq 302
       end
     end
   end

--- a/spec/controllers/admin/link_menus_controller_spec.rb
+++ b/spec/controllers/admin/link_menus_controller_spec.rb
@@ -11,21 +11,21 @@ describe Admin::LinkMenusController do
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
   describe "GET 'new'" do
     it "returns http success" do
       get :new
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
   describe "POST 'create'" do
     it "redirect to index" do
       post :create, {:link_menu => valid_attributes}, valid_session
-      response.should redirect_to(admin_link_menus_url)
+      expect(response).to redirect_to(admin_link_menus_url)
     end
   end
 
@@ -33,7 +33,7 @@ describe Admin::LinkMenusController do
     it "redirect to index" do
       link_menu = LinkMenu.create! valid_attributes
       put :update, {:id => link_menu.to_param, link_menu: valid_attributes}, valid_session
-      response.should redirect_to(admin_link_menus_url)
+      expect(response).to redirect_to(admin_link_menus_url)
     end
   end
 
@@ -41,7 +41,7 @@ describe Admin::LinkMenusController do
     it "redirect to link_menus list" do
       link_menu = LinkMenu.create! valid_attributes
       delete :destroy, {:id => link_menu.to_param, link_menu: valid_attributes}, valid_session
-      response.should redirect_to(admin_link_menus_url)
+      expect(response).to redirect_to(admin_link_menus_url)
     end
   end
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -37,14 +37,14 @@ describe CategoriesController do
     it "assigns all categories as @categories" do
       category = Category.create! valid_attributes
       get :index, {}, valid_session
-      assigns(:categories).should eq([category])
+      expect(assigns(:categories)).to eq([category])
     end
   end
 
   describe "GET new" do
     it "assigns a new category as @category" do
       get :new, {}, valid_session
-      assigns(:category).should be_a_new(Category)
+      expect(assigns(:category)).to be_a_new(Category)
     end
   end
 
@@ -52,7 +52,7 @@ describe CategoriesController do
     it "assigns the requested category as @category" do
       category = Category.create! valid_attributes
       get :edit, {:id => category.to_param}, valid_session
-      assigns(:category).should eq(category)
+      expect(assigns(:category)).to eq(category)
     end
   end
 
@@ -66,32 +66,32 @@ describe CategoriesController do
 
       it "assigns a newly created category as @category" do
         post :create, {:category => valid_attributes}, valid_session
-        assigns(:category).should be_a(Category)
-        assigns(:category).should be_persisted
+        expect(assigns(:category)).to be_a(Category)
+        expect(assigns(:category)).to be_persisted
       end
 
       it "redirects to the created category" do
         post :create, {:category => valid_attributes}, valid_session
-        response.should redirect_to(categories_url)
+        expect(response).to redirect_to(categories_url)
       end
     end
 
     describe "with invalid params" do
       before do
-        Category.any_instance.stub(:save).and_return(false)
-        Category.any_instance.stub(:errors).and_return({ name: "invalid" })
+        allow_any_instance_of(Category).to receive(:save).and_return(false)
+        allow_any_instance_of(Category).to receive(:errors).and_return({ name: "invalid" })
       end
 
       it "assigns a newly created but unsaved category as @category" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:category => { "name" => "" }}, valid_session
-        assigns(:category).should be_a_new(Category)
+        expect(assigns(:category)).to be_a_new(Category)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:category => { "name" => "" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end
@@ -104,40 +104,40 @@ describe CategoriesController do
         # specifies that the Category created on the previous line
         # receives the :update_attributes message with whatever params are
         # submitted in the request.
-        Category.any_instance.should_receive(:update).with({ "name" => "MyString" })
+        expect_any_instance_of(Category).to receive(:update).with({ "name" => "MyString" })
         put :update, {:id => category.to_param, :category => { "name" => "MyString" }}, valid_session
       end
 
       it "assigns the requested category as @category" do
         category = Category.create! valid_attributes
         put :update, {:id => category.to_param, :category => valid_attributes}, valid_session
-        assigns(:category).should eq(category)
+        expect(assigns(:category)).to eq(category)
       end
 
       it "redirects to the category" do
         category = Category.create! valid_attributes
         put :update, {:id => category.to_param, :category => valid_attributes}, valid_session
-        response.should redirect_to(categories_url)
+        expect(response).to redirect_to(categories_url)
       end
     end
 
     describe "with invalid params" do
       let(:category) { Category.create! valid_attributes }
       before do
-        Category.any_instance.stub(:save).and_return(false)
-        Category.any_instance.stub(:errors).and_return({ name: "invalid" })
+        allow_any_instance_of(Category).to receive(:save).and_return(false)
+        allow_any_instance_of(Category).to receive(:errors).and_return({ name: "invalid" })
       end
 
       it "assigns the category as @category" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => category.to_param, :category => { "name" => "" }}, valid_session
-        assigns(:category).should eq(category)
+        expect(assigns(:category)).to eq(category)
       end
 
       it "re-renders the 'edit' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         put :update, {:id => category.to_param, :category => { "name" => "" }}, valid_session
-        response.should render_template("edit")
+        expect(response).to render_template("edit")
       end
     end
   end

--- a/spec/controllers/expenses_controller_spec.rb
+++ b/spec/controllers/expenses_controller_spec.rb
@@ -12,7 +12,7 @@ describe ExpensesController do
   describe "GET 'index'" do
     it "returns http success" do
       get :index
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -21,14 +21,14 @@ describe ExpensesController do
       item = Expense.create! valid_attributes
       get :show, { id: item.id }
       expect(assigns(:expense)).to eq item
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
   describe "GET 'new'" do
     it "returns http success" do
       get :new, { expense: valid_attributes }
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -42,29 +42,29 @@ describe ExpensesController do
 
       it "assigns a newly created expense as @expense" do
         post :create, {expense: valid_attributes}
-        assigns(:expense).should be_a(Expense)
-        assigns(:expense).should be_persisted
+        expect(assigns(:expense)).to be_a(Expense)
+        expect(assigns(:expense)).to be_persisted
       end
 
       it "redirects to the expenses" do
         post :create, {expense: valid_attributes}
-        response.should redirect_to(expenses_url)
+        expect(response).to redirect_to(expenses_url)
       end
     end
 
     describe "with invalid params" do
       it "assigns a newly created but unsaved expense as @expense" do
         # Trigger the behavior that occurs when invalid params are submitted
-        Expense.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Expense).to receive(:save).and_return(false)
         post :create, {expense: { amount: "invalid value" }}
-        assigns(:expense).should be_a_new(Expense)
+        expect(assigns(:expense)).to be_a_new(Expense)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
-        Expense.any_instance.stub(:save).and_return(false)
+        allow_any_instance_of(Expense).to receive(:save).and_return(false)
         post :create, {expense: { amount: "invalid value" }}
-        response.status.should eq 302
+        expect(response.status).to eq 302
       end
     end
   end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -9,7 +9,7 @@ describe HomeController do
   describe "GET 'index'" do
     it "should be successful" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 

--- a/spec/controllers/incomes_controller_spec.rb
+++ b/spec/controllers/incomes_controller_spec.rb
@@ -12,7 +12,7 @@ describe IncomesController do
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -21,14 +21,14 @@ describe IncomesController do
       item = Income.create! valid_attributes
       get 'show', { id: item.id }
       expect(assigns(:income)).to eq item
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
   describe "GET 'new'" do
     it "returns http success" do
       get 'new', { income: valid_attributes }
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -42,26 +42,26 @@ describe IncomesController do
 
       it "assigns a newly created income as @income" do
         post :create, { income: valid_attributes }
-        assigns(:income).should be_a(Income)
-        assigns(:income).should be_persisted
+        expect(assigns(:income)).to be_a(Income)
+        expect(assigns(:income)).to be_persisted
       end
 
       it "redirect to the incomes" do
         post :create, { income: valid_attributes }
-        response.should redirect_to(incomes_path)
+        expect(response).to redirect_to(incomes_path)
       end
 
       context "with invalid params" do
         it "assignes a newly created but unsaved incomes as@income" do
-          Income.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Income).to receive(:save).and_return(false)
           post :create, { income: { amount: "invalid value" } }
-          assigns(:income).should be_a_new(Income)
+          expect(assigns(:income)).to be_a_new(Income)
         end
 
         it "re-renders the 'new' template" do
-          Income.any_instance.stub(:save).and_return(false)
+          allow_any_instance_of(Income).to receive(:save).and_return(false)
           post :create, { income: { amount: "invalid value" } }
-          response.status.should eq 302
+          expect(response.status).to eq 302
         end
       end
     end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -14,7 +14,7 @@ describe MembersController do
   describe "GET 'index'" do
     it "returns http success" do
       get 'index'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -23,14 +23,14 @@ describe MembersController do
       item = Member.create! valid_attributes
       get :show, { id: item.id }
       expect(assigns(:member)).to eq item
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
   describe "GET 'new'" do
     it "returns http success" do
       get 'new'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -44,32 +44,32 @@ describe MembersController do
 
       it "assigns a newly created member as @member" do
         post :create, {member: valid_attributes}
-        assigns(:member).should be_a(Member)
-        assigns(:member).should be_persisted
+        expect(assigns(:member)).to be_a(Member)
+        expect(assigns(:member)).to be_persisted
       end
 
       it "redirects to the members" do
         post :create, {member: valid_attributes}
-        response.should redirect_to(members_url)
+        expect(response).to redirect_to(members_url)
       end
     end
 
     describe "with invalid params" do
       before do
-        Member.any_instance.stub(:save).and_return(false)
-        Member.any_instance.stub(:errors).and_return({ fullname: "invalid" })
+        allow_any_instance_of(Member).to receive(:save).and_return(false)
+        allow_any_instance_of(Member).to receive(:errors).and_return({ fullname: "invalid" })
       end
 
       it "assigns a newly created but unsaved member as @member" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:member => { "fullname" => "" }}, valid_session
-        assigns(:member).should be_a_new(Member)
+        expect(assigns(:member)).to be_a_new(Member)
       end
 
       it "re-renders the 'new' template" do
         # Trigger the behavior that occurs when invalid params are submitted
         post :create, {:member => { "fullname" => "" }}, valid_session
-        response.should render_template("new")
+        expect(response).to render_template("new")
       end
     end
   end

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -25,7 +25,7 @@ describe SummaryController do
 
     it "returns http success" do
       get 'show'
-      response.should be_success
+      expect(response).to be_success
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 3.4.0 with the following command:
    transpec

* 69 conversions
    from: obj.should
      to: expect(obj).to

* 18 conversions
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 3 conversions
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions